### PR TITLE
Squeezing on one specific axis to prevent excessive squeezing

### DIFF
--- a/Elmo Keras.ipynb
+++ b/Elmo Keras.ipynb
@@ -188,7 +188,7 @@
     "# We create a function to integrate the tensorflow model with a Keras model\n",
     "# This requires explicitly casting the tensor to a string, because of a Keras quirk\n",
     "def ElmoEmbedding(x):\n",
-    "    return elmo_model(tf.squeeze(tf.cast(x, tf.string)), signature=\"default\", as_dict=True)[\"default\"]\n",
+    "    return elmo_model(tf.squeeze(tf.cast(x, tf.string), axis=1), signature=\"default\", as_dict=True)[\"default\"]\n",
     " \n",
     "input_text = layers.Input(shape=(1,), dtype=tf.string)\n",
     "embedding = layers.Lambda(ElmoEmbedding, output_shape=(1024,))(input_text)\n",


### PR DESCRIPTION
When the input to `ElmoEmbedding(x)` has shape `(1, 1)`, the original code would squeeze both axes. This change prevents that behavior by specifying the axis to squeeze.